### PR TITLE
Change "ES7" to something more appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ES7 Proposal: The Pipeline Operator
+# ES2016 Proposal: The Pipeline Operator
 
 *Note: Although the JS community is excited about this proposal, its syntax is somewhat controversial. See [Issue #4](https://github.com/mindeavor/es-pipeline-operator/issues/4) for alternative syntaxes and discussion.*
 


### PR DESCRIPTION
To my knowledge TC39 has moved to a train model for spec releases. As part of this change they've switched from the `ES#` naming scheme to `ESYYYY` where YYYY is the release year. As such, ES6 became ES2015 and ES7 became ES2016.

The title of the readme should be changed to better match the TC's current naming conventions. I propose that "ES2016 Proposal" be replaced with either "ES2016 Proposal" or "ECMAScript Proposal". I've also seen some members of the community propose that "ES.next" would refer to the next release of the spec or "ES.future" to refer to features that haven't yet been added to release train.