### PR TITLE
Use ES6 syntax where appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ function exclaim (str) {
 ...the following invocations are equivalent:
 
 ```js
-var result = exclaim(capitalize(doubleSay("hello")));
+let result = exclaim(capitalize(doubleSay("hello")));
 result //=> "Hello, hello!"
 
-var result = "hello"
+let result = "hello"
   |> doubleSay
   |> capitalize
   |> exclaim;
@@ -55,23 +55,23 @@ function double (x) { return x + x; }
 function add (x, y) { return x + y; }
 
 function validateScore (score) {
-  return Math.max(0, Math.min(100, score))
+  return Math.max(0, Math.min(100, score));
 }
 ```
 
 ...you can use an arrow function to handle multi-argument functions (such as `add`):
 
 ```js
-var person = { score: 25 };
+let person = { score: 25 };
 
-var newScore = person.score
+let newScore = person.score
   |> double
   |> score => add(7, score)
-  |> validateScore
+  |> validateScore;
 
 newScore //=> 57
 
-// As opposed to: var newScore = validateScore( add(7, double(person.score)) )
+// As opposed to: let newScore = validateScore( add(7, double(person.score)) )
 ```
 
 As you can see, because the pipe operator always pipes a single result value, it plays very nicely with the single-argument arrow function syntax. Also, because the pipe operator's semantics are pure and simple, it could be possible for JavaScript engines to optimize away the arrow function.
@@ -90,17 +90,17 @@ function greets (person) {
   return person;
 }
 function ages (age) {
-  return function (person) {
+  return person => {
     person.age = age;
-    person.birthday = function () { person.age += 1; };
+    person.birthday = () => { person.age += 1; };
     return person;
   }
 }
 function programs (favLang) {
-  return function (person) {
+  return person => {
     person.favLang = favLang;
     person.program = () => `${person.name} starts to write ${person.favLang}!`;
-    return person
+    return person;
   }
 }
 ```
@@ -109,13 +109,13 @@ function programs (favLang) {
 
 ```js
 function Person (name, age) {
-  return { name: name } |> greets |> ages(age)
+  return { name: name } |> greets |> ages(age);
 }
 function Programmer (name, age) {
   return { name: name }
     |> greets
     |> ages(age)
-    |> programs('javascript')
+    |> programs('javascript');
 }
 ```
 
@@ -125,14 +125,14 @@ Validation is a great use case for pipelining functions. For example, given the 
 
 ```js
 function bounded (prop, min, max) {
-  return function (obj) {
+  return obj => {
     if ( obj[prop] < min || obj[prop] > max ) throw Error('out of bounds');
     return obj;
   };
 }
 function format (prop, regex) {
-  return function (obj) {
-    if ( ! regex.test(obj[prop]) ) throw Error('invalid format')
+  return obj => {
+    if ( ! regex.test(obj[prop]) ) throw Error('invalid format');
     return obj;
   };
 }
@@ -145,7 +145,7 @@ function createPerson (attrs) {
   attrs
     |> bounded('age', 1, 100)
     |> format('name', /^[a-z]$/i)
-    |> Person.insertIntoDatabase
+    |> Person.insertIntoDatabase;
 }
 ```
 
@@ -156,13 +156,13 @@ Although the pipe operator operates well with functions that don't use `this`, i
 ```js
 
 fetchPlayers()
-  .then(function (players) {
+  .then( players => {
     return players
       .filter( p => p.score > 100 )
       .map( p => fetchGames(p) )
-      |> Promise.all
+      |> Promise.all;
   })
-  .then(function (playerGames) {
+  .then( playerGames => {
     // ...
   })
 
@@ -178,7 +178,7 @@ fetchPlayers()
   .then( games => Promise.all(games) )
   .then( processGames )
   |> catchError( ProcessError, err => [] )
-  |> then( forEach(g => console.log(g)) )
+  |> then( forEach(g => console.log(g)) );
 
 function catchError (ErrorClass, handler) {
   return promise => promise.catch(catcher);
@@ -189,8 +189,8 @@ function catchError (ErrorClass, handler) {
   }
 }
 
-function then (handler) {  return promise => promise.then(handler)  }
-function forEach (fn) {  return array => array.forEach(fn)  }
+function then (handler) {  return promise => promise.then(handler);  }
+function forEach (fn) {  return array => array.forEach(fn);  }
 ```
 
 This example is significant because we have added useful Promise functionality (`catchError` catches specific rejection errors) **without extending the Promise prototype itself**. If we wanted to add catchError-like functionality using ES6 and stay fluent, we would have to either *extend* Promise.prototype, or *re-implement* the Promise interface (as [bluebird](https://github.com/petkaantonov/bluebird) and others have done).

--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ function greets (person) {
   return person;
 }
 function ages (age) {
-  return person => {
+  return function (person) {
     person.age = age;
-    person.birthday = () => { person.age += 1; };
+    person.birthday = function () { person.age += 1; };
     return person;
   }
 }
 function programs (favLang) {
-  return person => {
+  return function (person) {
     person.favLang = favLang;
     person.program = () => `${person.name} starts to write ${person.favLang}!`;
     return person;
@@ -125,13 +125,13 @@ Validation is a great use case for pipelining functions. For example, given the 
 
 ```js
 function bounded (prop, min, max) {
-  return obj => {
+  return function (obj) {
     if ( obj[prop] < min || obj[prop] > max ) throw Error('out of bounds');
     return obj;
   };
 }
 function format (prop, regex) {
-  return obj => {
+  return function (obj) {
     if ( ! regex.test(obj[prop]) ) throw Error('invalid format');
     return obj;
   };
@@ -156,13 +156,13 @@ Although the pipe operator operates well with functions that don't use `this`, i
 ```js
 
 fetchPlayers()
-  .then( players => {
+  .then(function (players) {
     return players
       .filter( p => p.score > 100 )
       .map( p => fetchGames(p) )
       |> Promise.all;
   })
-  .then( playerGames => {
+  .then(function (playerGames) {
     // ...
   })
 


### PR DESCRIPTION
I think the examples are easier to understand if they use arrow functions all the way. I've also fixed some of the inconsistencies with semicolon usage.