### PR TITLE
New version of Pipeline Operator proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ This example is significant because we have added useful Promise functionality (
 
 ## Syntax Behavior
 
-The pipeline operator is quick – it matches the first invocation it sees. If there is no invocation, a Syntax Error is thrown.
+In general, the pipeline operator matches the first invocation it sees. If there is no invocation, a Syntax Error is thrown.
 
 ```js
 //

--- a/README.md
+++ b/README.md
@@ -82,6 +82,32 @@ Piping to the last argument allows easy use of multiple-parameter functions, wit
 
 ## Motivating Examples
 
+### Validation
+
+Validation is a great use case for pipelining functions. For example, given the following validators:
+
+```js
+function bounded (prop, min, max, obj) {
+  if ( obj[prop] < min || obj[prop] > max ) throw Error('out of bounds');
+  return obj;
+}
+function format (prop, regex, obj) {
+  if ( ! regex.test(obj[prop]) ) throw Error('invalid format')
+  return obj;
+}
+```
+
+...we can use the pipeline operator to validate objects quite pleasantly:
+
+```js
+function createPerson (attrs) {
+  attrs
+    |> bounded('age', 1, 100)
+    |> format('name', /^[a-z]$/i)
+    |> Person.insertIntoDatabase();
+}
+```
+
 ### Object Decorators
 
 Mixins via `Object.assign` are great, but sometimes you need something more advanced. A **decorator function** is a function that receives an existing object, adds to it (mutative or not), and then returns the result.
@@ -116,32 +142,6 @@ function Programmer (name, age) {
     |> greets()
     |> ages(age)
     |> programs('javascript');
-}
-```
-
-### Validation
-
-Validation is a great use case for pipelining functions. For example, given the following validators:
-
-```js
-function bounded (prop, min, max, obj) {
-  if ( obj[prop] < min || obj[prop] > max ) throw Error('out of bounds');
-  return obj;
-}
-function format (prop, regex, obj) {
-  if ( ! regex.test(obj[prop]) ) throw Error('invalid format')
-  return obj;
-}
-```
-
-...we can use the pipeline operator to validate objects quite pleasantly:
-
-```js
-function createPerson (attrs) {
-  attrs
-    |> bounded('age', 1, 100)
-    |> format('name', /^[a-z]$/i)
-    |> Person.insertIntoDatabase();
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ES7 Proposal: The Pipeline Operator
 
+*NOTE: This version of the pipeline operator proposal is [currently being discussed here](https://github.com/mindeavor/es-pipeline-operator/issues/20).*
+
 This proposal introduces a new operator `|>` similar to
   [F#](https://en.wikibooks.org/wiki/F_Sharp_Programming/Higher_Order_Functions#The_.7C.3E_Operator),
   [OCaml](http://caml.inria.fr/pub/docs/manual-ocaml/libref/Pervasives.html#VAL%28|%3E%29),

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ function bounded (prop, min, max, obj) {
   return obj;
 }
 function format (prop, regex, obj) {
-  if ( ! regex.test(obj[prop]) ) throw Error('invalid format')
+  if ( ! regex.test(obj[prop]) ) throw Error('invalid format');
   return obj;
 }
 ```
@@ -166,7 +166,7 @@ getAllPlayers()
 //   Lazy( getAllPlayers().filter( p => p.score > 100).sort() )
 //   .map( p => p.name )
 //   .take(5)
-// }
+// );
 ```
 
 As you can see, the pipeline operator populates the very first invocation it finds with its argument. This is critical for allowing a fluent programming style, interwieving function calls with method calls.


### PR DESCRIPTION
In short: Pipe left-hand-side of operator into last argument of right-hand-side. You can [see the full README here](https://github.com/mindeavor/es-pipeline-operator/tree/inline).

Quick summary of benefits:

- There is no longer any overhead of pipelining functions that take multiple arguments [[explanation](https://github.com/mindeavor/es-pipeline-operator/tree/inline#functions-with-multiple-arguments)]
- Much easier use with JS functions Functions no longer need to be curried to be used effectively [[example](https://github.com/mindeavor/es-pipeline-operator/tree/inline#validation)]
- Integration with prototype methods is way better [[example](https://github.com/mindeavor/es-pipeline-operator/tree/inline#usage-with-prototypes)]