### PR TITLE
spec/explainer: Clarify “precedence” with conditional expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,12 +675,13 @@ then evaluates its righthand side (the **pipe body**) with that binding.
 The resulting value of the righthand side
 becomes the whole pipe expression’s final value (the **pipe output**).
 
-The pipe operator’s precedence is the **same** as:
+The pipe operator’s precedence is **similar** to:
+* the ternary conditional operator `?` `:`;
 * the function arrow `=>`;
-* the assignment operators `=`, `+=`, etc.;
-* the generator operators `yield` and `yield *`;
+* the assignment operators `=`, `+=`, etc.; and
+* the generator operators `yield` and `yield *`.
 
-It is **tighter** than only the comma operator `,`.\
+It is **tighter** than the comma operator `,`.\
 It is **looser** than **all other** operators.
 
 For example, `v => v |> % == null |> foo(%, 0)`\
@@ -699,15 +700,31 @@ Using a topic reference outside of a pipe body
 is also **invalid syntax**.
 
 To prevent confusing grouping,
-it is **invalid** syntax to use **other** operators that have **similar precedence**
+it is **invalid** syntax to directly use **other** operators
+that have **similar precedence**
 (i.e., the arrow `=>`, the ternary conditional operator `?` `:`,
 the assignment operators, and the `yield` operator)
 as a **pipe head or body**.
 When using `|>` with these operators, we must use **parentheses**
 to explicitly indicate what grouping is correct.
-For example, `a |> b ? % : c |> %.d` is invalid syntax;
-it should be corrected to either `a |> (b ? % : c) |> %.d`
-or `a |> (b ? % : c |> %.d)`.
+
+For example, `a ? b : c |> d(%) |> e(%)` is invalid syntax.
+Parentheses need to be added to explicitly choose
+between `(a ? b : c) |> d(%) |> e(%)` and `a ? b : (c |> d(%) |> e(%))`.
+
+Likewise, `a |> b ? % : c |> d(%)` is invalid syntax.
+Parentheses need to be added: `a |> (b ? % : c) |> d(%)`.
+
+The same goes for `a |> b => c(%) |> d(%)`.
+Parentheses need to be added to explicitly choose
+between `a |> (b => c(%)) |> d(%)`
+and `a |> (b => c(%) |> d(%))`.
+
+(Note: `x = a |> b(%)`, `x => a |> b(%)`, and `yield a |> b(%)` are allowed;
+they group as `x = (a |> b(%))`, `x => (a |> b(%))`, and `yield (a |> b(%))`.
+However, `a |> x = b(%)`, `a |> x = b(%)`, and `a |> yield b(%)` are invalid
+without parentheses. We must use `a |> (x = b(%))`, `a |> (x = b(%))`,
+and `a |> (yield b(%))`.)
 
 Lastly, topic bindings **inside dynamically compiled** code
 (e.g., with `eval` or `new Function`)

--- a/spec.html
+++ b/spec.html
@@ -142,6 +142,11 @@ contributors: J. S. Choi, James DiGioia, Ron Buckton, Tab Atkins-Bittner
         1. Return *false*.
       </emu-alg>
 
+      <emu-note>
+        <p>This algorithm ensures that the remainder expression `x % 2` is not
+        considered to contain a topic reference.</p>
+      </emu-note>
+
       <emu-grammar>PipeBody : AssignmentExpression</emu-grammar>
 
       <emu-alg>
@@ -660,6 +665,43 @@ contributors: J. S. Choi, James DiGioia, Ron Buckton, Tab Atkins-Bittner
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-conditional-operator">
+    <h1>Conditional Operator ( `? :` )</h1>
+    <h2>Syntax</h2>
+    <emu-grammar type="definition">
+      ConditionalExpression[In, Yield, Await] :
+        ShortCircuitExpression[?In, ?Yield, ?Await]
+        ShortCircuitExpression[?In, ?Yield, ?Await] `?` AssignmentExpression[+In, ?Yield, ?Await] `:` AssignmentExpression[?In, ?Yield, ?Await]
+    </emu-grammar>
+
+    <emu-clause id="sec-conditional-operator-static-early-errors">
+      <h1><ins>Static Semantics: Early Errors</ins></h1>
+
+      <emu-note type=editor>
+        <p>This section is a wholly new sub-clause to be inserted at the end of
+        the <a
+        href=https://tc39.github.io/ecma262/#sec-conditional-operator>original
+        Conditional Operator (`?` `:`) clause</a>.</p>
+      </emu-note>
+
+      <emu-grammar>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
+      <emu-alg>
+        1. It is a Syntax Error if |PipeExpression| is covering the first |AssignmentExpression| or the second |AssignmentExpression|.
+      </emu-alg>
+      <emu-note>
+        <p>None of the three expressions that form a ternary
+        |ConditionalExpression| may be an unparenthesized |PipeExpression|.
+        This is to prevent ambiguous expressions such as
+        `a ? b : c |> d(%) |> e(%)`,<br>
+        which may otherwise be parsed equivalently to both
+        `(a ? b : c) |> d(%) |> e(%)` and
+        `a ? b : (c |> d(%) |> e(%))`.<br>
+        Parentheses must be used to explicitly distinguish
+        between the two possible parsings.</p>
+      </emu-note>
+    </emu-clause>
+  </emu-clause>
+
   <emu-clause id=sec-pipe-operator>
     <h1><ins>Pipe Operator</ins></h1>
 
@@ -718,7 +760,10 @@ contributors: J. S. Choi, James DiGioia, Ron Buckton, Tab Atkins-Bittner
       </emu-alg>
 
       <emu-note>
-        <p>A |PipeBody| must not be an unparenthesized expression that is formed from any other operator with identical precedence (such as |YieldExpression| or |ArrowFunction|) or from the <emu-xref="#sec-conditional-operator">conditional operator</emu-xref>.</p>
+        <p>A |PipeBody| must not be an unparenthesized expression that is formed
+        from `yield`, `=>`, an assignment operator, or the
+        <emu-xref="#sec-conditional-operator">conditional
+        operator</emu-xref>.</p>
         <p>This is to prevent confusing expressions from being valid, such as
         `x |> yield % |> % + 1`.<br>
         That expression would otherwise be unexpectedly equivalent to
@@ -727,7 +772,8 @@ contributors: J. S. Choi, James DiGioia, Ron Buckton, Tab Atkins-Bittner
         `x |> y ? % : z |> % + 1`.<br>
         would otherwise be unexpectedly equivalent to
         `x |> (y ? % : z |> % + 1)`.</p>
-        <p>Such invalid expressions would become valid with explicit parentheses:
+        <p>Such invalid expressions would become valid with explicit
+        parentheses:
         `x |> (yield %) |> % + 1` or<br>
         `x |> (yield % |> % + 1)`;<br>
         `x |> (y ? % : z) |> % + 1` or<br>


### PR DESCRIPTION
Prohibit ambiguous conditional expression ending with pipe expression, e.g., `a ? b : c |> d(%) |> e(%)`. See https://github.com/tc39/proposal-pipeline-operator/issues/262#issuecomment-1036510623.